### PR TITLE
Removed warnings compiling and trailing whitespaces

### DIFF
--- a/lib/charset.c
+++ b/lib/charset.c
@@ -6,12 +6,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- 
+
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- 
+
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -55,6 +55,6 @@ int validCode(char *code){
             return 0;
         if(! isalnum(code[i]))
             return 0;
-    }   
+    }
     return 1;
 }

--- a/lib/drop_privs.c
+++ b/lib/drop_privs.c
@@ -4,24 +4,24 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
-#include <syslog.h> 
+#include <syslog.h>
 #include <sys/stat.h>
 #include <pwd.h>
 
 #include "drop_privs.h"
-   
-   
+
+
 static int   orig_ngroups = -1;
 static gid_t orig_gid = -1;
 static uid_t orig_uid = -1;
 static gid_t orig_groups[NGROUPS_MAX];
-   
+
 
 
 int drop_privileges(int permanent) {
     gid_t newgid = getgid(), oldgid = getegid();
     uid_t newuid = getuid(), olduid = geteuid();
-   
+
     if (!permanent && orig_uid == -1 && orig_gid == -1 && orig_ngroups == -1) {
         /* Save information about the privileges that are being dropped so that they
          * can be restored later. Only once.
@@ -37,7 +37,7 @@ int drop_privileges(int permanent) {
     * whether privileges are being dropped temporarily or permanently.
     */
     if (!olduid) setgroups(1, &newgid);
-   
+
     if (newgid != oldgid) {
 #if !defined(linux)
         setegid(newgid);
@@ -46,7 +46,7 @@ int drop_privileges(int permanent) {
         if (setregid((permanent ? newgid : -1), newgid) == -1) return -1;
 #endif
     }
- 
+
     if (newuid != olduid) {
         if (permanent) {
             setuid(newuid);
@@ -54,7 +54,7 @@ int drop_privileges(int permanent) {
             seteuid(newuid);
         }
     }
- 
+
     /* verify that the changes were successful */
     if (permanent) {
         if (newgid != oldgid && (setegid(oldgid) != -1 || getegid() != newgid))
@@ -68,10 +68,10 @@ int drop_privileges(int permanent) {
 
     return 0;
 }
-   
+
 int restore_privileges(void) {
     if (geteuid() != orig_uid)
-        if (seteuid(orig_uid) == -1 || geteuid() != orig_uid) return -1;   
+        if (seteuid(orig_uid) == -1 || geteuid() != orig_uid) return -1;
     if (getegid() != orig_gid)
         if (setegid(orig_gid) == -1 || getegid() != orig_gid) return -1;
     if (!orig_uid)

--- a/lib/latch.c
+++ b/lib/latch.c
@@ -6,12 +6,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- 
+
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- 
+
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -68,7 +68,7 @@ typedef struct http_param {
 
 /*
  * Function to handle stuff from HTTP response.
- * 
+ *
  * @param buf- Raw buffer from libcurl.
  * @param len- number of indexes
  * @param size- size of each index
@@ -92,7 +92,7 @@ static int writeFn(void* buf, size_t len, size_t size, void* userdata) {
 
 /*
  * Function to encode a string in Base64 format
- * 
+ *
  * @param input- string to encode
  * @param length- string length
  * @return encoded string in Base64 format
@@ -157,7 +157,7 @@ char* urlEncode(const char* str, int space2Plus) {
 
 /*
  * Function to calculate the HMAC hash (SHA1) of a string. Returns a Base64 value of the hash
- * 
+ *
  * @param pSecretKey- secret key
  * @param pData- original data to calculate the HMAC
  * @return HMAC in Base64 format

--- a/lib/util.c
+++ b/lib/util.c
@@ -6,12 +6,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- 
+
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- 
+
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h> 
+#include <syslog.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <pwd.h>
@@ -105,21 +105,21 @@ int deleteAccountId(const char* pUsername, const char* pAccounts) {
         fclose(fp);
         return -1;
     }
-   
+
     while ((read = getline(&line,&len, fp)) != -1) {
         if (! (strncmp(pUsername, line, strlen(pUsername)) == 0  &&  line[strlen(pUsername)] == ':')) {
             if (write(fp_dest, line, read) != read) {
                 free(line);
                 close(fp_dest);
-                fclose(fp); 
-                return -1;  
+                fclose(fp);
+                return -1;
             }
         }
     }
 
     free(line);
     close(fp_dest);
-    fclose(fp); 
+    fclose(fp);
 
     if (rename(nameBuff, pAccounts) != 0) {
         return 1;
@@ -146,8 +146,8 @@ const char* getAccountId(const char* pUser, const char* pAccounts) {
     }
 
     while((read = getline(&line,&len, fp)) != -1){
-        if((read == strlen(pUser) + ACCOUNT_ID_LENGTH + 3)  &&  
-                strncmp(pUser, line, strlen(pUser)) == 0  &&  
+        if((read == strlen(pUser) + ACCOUNT_ID_LENGTH + 3)  &&
+                strncmp(pUser, line, strlen(pUser)) == 0  &&
                 line[strlen(pUser)] == ':'){
             toReturn = malloc(ACCOUNT_ID_LENGTH + 1);
             strncpy(toReturn, line + strlen(pUser) + 2, ACCOUNT_ID_LENGTH);
@@ -207,11 +207,11 @@ const char *getConfig(int max_size, const char* pParameter, const char* pConfig)
 
 /*
  * Log a message into auth logger
- * 
+ *
  * @param Message
  */
-void send_syslog_alert(char *ident, const char *msg){  
-    openlog (ident, LOG_PID, LOG_AUTH);    
-    syslog (LOG_ALERT, msg); 
+void send_syslog_alert(char *ident, const char *msg){
+    openlog (ident, LOG_PID, LOG_AUTH);
+    syslog (LOG_ALERT, msg);
     closelog ();
 }

--- a/modules/SSH/src/latch_ssh_command.c
+++ b/modules/SSH/src/latch_ssh_command.c
@@ -6,12 +6,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- 
+
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- 
+
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <string.h>
 #include "config.h"
 
 #include "latch.h"
@@ -32,7 +33,7 @@
 
 
 /* Usage: latch-shell [-o operation][-s][-f config_file][-a accounts_file]
- * Must be silent mode because of SFTP 
+ * Must be silent mode because of SFTP
  */
 
 
@@ -46,14 +47,14 @@ static int exec_shell(){
 
 static int latch_shell_status(const char *pAccountId, int defaultOption) {
     int res = 0;
-    char *buffer = NULL; 
+    char *buffer = NULL;
 
     if (pAccountId == NULL) {
         return 0;
     }
 
     buffer = status(pAccountId);
-          
+
     if(buffer == NULL || strcmp(buffer,"") == 0) {
         free(buffer);
         return defaultOption;
@@ -71,14 +72,14 @@ static int latch_shell_status(const char *pAccountId, int defaultOption) {
 
 static int latch_shell_operation_status(const char *pAccountId, const char *pOperationId, int defaultOption) {
     int res = 0;
-    char *buffer = NULL; 
+    char *buffer = NULL;
 
     if (pAccountId == NULL) {
         return 0;
     }
 
     buffer = operationStatus(pAccountId, pOperationId);
-        
+
     if(buffer == NULL || strcmp(buffer,"") == 0) {
         free(buffer);
         return defaultOption;
@@ -107,21 +108,21 @@ int main(int argc, char **argv) {
     int c;
     int error = 0;
     const char *pAccountId = NULL;
-    const char* pUsername = NULL;                
+    const char* pUsername = NULL;
     const char* pSecretKey = NULL;
     const char* pAppId = NULL;
     const char* pHost = NULL;
     const char* pTimeout = NULL;
     const char *pOperationId = NULL;
     char* pDefaultOption = NULL;
-    char *buffer;    
+    char *buffer;
     int timeout = 2;
     int res = 0;
     int default_option = 0;
     FILE *f;
 
     opterr = 0;
-  
+
 
     while ((c = getopt (argc, argv, "so:f:a:")) != -1) {
       switch(c) {
@@ -154,19 +155,19 @@ int main(int argc, char **argv) {
     if (error) {
         return exec_shell();
     }
-   
+
     pUsername = get_user_name();
     if (pUsername == NULL) {
         return exec_shell();
     }
-     
+
     if (avalue == NULL) {
         avalue = DEFAULT_LATCH_ACCOUNTS_FILE;
         aperms = 1;
     } else if (access(avalue, R_OK) != 0) {
         return 1;
     }
-      
+
     if (fvalue == NULL) {
         fvalue = DEFAULT_LATCH_CONFIG_FILE;
         fperms = 1;
@@ -180,7 +181,7 @@ int main(int argc, char **argv) {
 
     pAppId = getConfig(APP_ID_LENGTH, "app_id", fvalue);
     pSecretKey = getConfig(SECRET_KEY_LENGTH, "secret_key", fvalue);
-   
+
     if(pAppId == NULL || pSecretKey == NULL || strcmp(pAppId, "") == 0 || strcmp(pSecretKey, "") == 0){
         return exec_shell();
     }
@@ -188,10 +189,10 @@ int main(int argc, char **argv) {
     if(ovalue && ((pOperationId = getConfig(OPERATION_ID_LENGTH, ovalue, fvalue)) == NULL)) {
         return 1;
     }
-     
+
     pDefaultOption = (char*)getConfig(DEFAULT_OPTION_MAX_LENGTH, "action", fvalue);
     if (pDefaultOption == NULL) {
-        pDefaultOption = malloc(4 + 1); 
+        pDefaultOption = malloc(4 + 1);
         memset(pDefaultOption, 0, 4 + 1);
         strncpy(pDefaultOption, "open", 4);
     } else if (strcmp(pDefaultOption,"open") != 0 && strcmp(pDefaultOption,"close") != 0){
@@ -219,10 +220,10 @@ int main(int argc, char **argv) {
         timeout = 2;
     }
     free((char*)pTimeout);
- 
+
     if (!aperms && drop_privileges(0)) {
         return 1;
-    } 
+    }
 
     if (aperms && !fperms) {
         restore_privileges();
@@ -237,19 +238,19 @@ int main(int argc, char **argv) {
     init(pAppId, pSecretKey);
     setHost(pHost);
     setTimeout(timeout);
-           
+
     if (sflag) {
         res = latch_shell_status(pAccountId, default_option);
     } else if (ovalue) {
         res = latch_shell_operation_status(pAccountId, pOperationId, default_option);
-    } 
+    }
 
     free((char*)pAccountId);
     free((char*)pAppId);
     free((char*)pSecretKey);
     free((char*)pHost);
     free((char*)pOperationId);
-   
+
     if (! res) {
         res = exec_shell();
     }

--- a/pam/test.c
+++ b/pam/test.c
@@ -6,12 +6,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- 
+
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- 
+
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA

--- a/pam/test_pam.c
+++ b/pam/test_pam.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     }
 
     retval = pam_start("check_user", user, &conv, &pamh);
-        
+
     if (retval == PAM_SUCCESS)
         retval = pam_authenticate(pamh, 0);    /* is user really user? */
 

--- a/src/latch_unix.c
+++ b/src/latch_unix.c
@@ -6,12 +6,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- 
+
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- 
+
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <errno.h>
+#include <string.h>
 
 #include "latch_unix.h"
 #include "latch.h"
@@ -45,7 +46,7 @@ void print_version() {
 static int latch_pair(const char *username, const char *pAccountId, const char *accountsFile, int aperms, char *pairingCode) {
     int res = 0;
     char *acc_id = NULL;
-    char *buffer = NULL; 
+    char *buffer = NULL;
     char *pstr = NULL;
 
     if (pAccountId != NULL) {
@@ -102,7 +103,7 @@ static int latch_pair(const char *username, const char *pAccountId, const char *
 
 static int latch_unpair(const char *username, const char *pAccountId, const char *accountsFile, int aperms) {
     int res = 0;
-    char *buffer = NULL; 
+    char *buffer = NULL;
 
     if (pAccountId == NULL) {
         fprintf(stderr, NOT_PAIRED_$USER_MSG, username);
@@ -111,7 +112,7 @@ static int latch_unpair(const char *username, const char *pAccountId, const char
 
     if (aperms && restore_privileges()) {
         printf("%s\n", RESTORE_PRIVS_ERROR_MSG);
-    } 
+    }
 
     if (deleteAccountId(username, accountsFile) != 0) {
         fprintf(stderr, "%s %s\n", WRITE_ACC_FILE_ERROR_MSG, accountsFile);
@@ -133,7 +134,7 @@ static int latch_unpair(const char *username, const char *pAccountId, const char
 
 static int latch_status(const char *username, const char *pAccountId) {
     int res = 0;
-    char *buffer = NULL; 
+    char *buffer = NULL;
 
     if (pAccountId == NULL) {
         fprintf(stderr, NOT_PAIRED_$USER_MSG, username);
@@ -173,7 +174,7 @@ static int latch_status(const char *username, const char *pAccountId) {
 
 static int latch_operation_status(const char *username, const char *pAccountId, const char *pOperationId) {
     int res = 0;
-    char *buffer = NULL; 
+    char *buffer = NULL;
 
     if (pAccountId == NULL) {
         fprintf(stderr, NOT_PAIRED_$USER_MSG, username);
@@ -230,18 +231,18 @@ int main(int argc, char **argv) {
     int index = 0;
     int c;
     const char *pAccountId = NULL;
-    const char* pUsername = NULL;                
+    const char* pUsername = NULL;
     const char *pSecretKey = NULL;
     const char *pAppId = NULL;
     const char *pHost = NULL;
-    const char *pTimeout = NULL; 
-    const char *pOperationId = NULL;  
+    const char *pTimeout = NULL;
+    const char *pOperationId = NULL;
     int timeout = 2;
     int res = 0;
     FILE *f;
 
     opterr = 0;
-  
+
     if (argc < 2) {
         print_usage();
         return 1;
@@ -306,13 +307,13 @@ int main(int argc, char **argv) {
          print_usage();
          return 1;
     }
-           
+
     pUsername = get_user_name();
     if (pUsername == NULL) {
         fprintf(stderr, "%s\n", GET_USERNAME_ERROR_MSG);
         return 1;
     }
-      
+
     if (avalue == NULL) {
         avalue = DEFAULT_LATCH_ACCOUNTS_FILE;
         aperms = 1;
@@ -320,7 +321,7 @@ int main(int argc, char **argv) {
         fprintf(stderr, ACCESS_RW_ERROR_$USER_$FILE_MSG, pUsername, avalue);
         return 1;
     }
-      
+
     if (fvalue == NULL) {
         fvalue = DEFAULT_LATCH_CONFIG_FILE;
         fperms = 1;
@@ -328,7 +329,7 @@ int main(int argc, char **argv) {
         fprintf(stderr, ACCESS_R_ERROR_$USER_$FILE_MSG, pUsername, fvalue);
         return 1;
     }
-      
+
     if (!fperms && drop_privileges(0)) {
         printf("%s\n", DROP_PRIVS_ERROR_MSG);
         return 1;
@@ -363,21 +364,21 @@ int main(int argc, char **argv) {
     if (!aperms && drop_privileges(0)) {
         printf("%s\n", DROP_PRIVS_ERROR_MSG);
         return 1;
-    } 
+    }
 
     if (aperms && !fperms && restore_privileges()) {
         printf("%s\n", RESTORE_PRIVS_ERROR_MSG);
-    }    
+    }
 
     pAccountId = getAccountId(pUsername, avalue);
- 
+
 	if (drop_privileges(0)) {
     	printf("%s\n", DROP_PRIVS_ERROR_MSG);
     	return 1;
 	}
 
     init(pAppId, pSecretKey);
-    setHost(pHost);    
+    setHost(pHost);
     setTimeout(timeout);
 
     if (sflag) {
@@ -391,7 +392,7 @@ int main(int argc, char **argv) {
     }
 
     free((char*)pAccountId);
-    free((char*)pAppId); 
+    free((char*)pAppId);
     free((char*)pSecretKey);
     free((char*)pHost);
     free((char*)pOperationId);

--- a/test/unit_test/CUnitAllTest.c
+++ b/test/unit_test/CUnitAllTest.c
@@ -104,13 +104,13 @@ int main(int argc, char *argv[]){
     /*
     CU_list_tests_to_file();
     CU_set_output_filename(output_file);
-    CU_automated_run_tests();        
+    CU_automated_run_tests();
     */
-    /* Run all tests using the CUnit Basic interface */   
-    
+    /* Run all tests using the CUnit Basic interface */
+
     CU_basic_set_mode(CU_BRM_VERBOSE);
     CU_basic_run_tests();
-    
+
 
     CU_cleanup_registry();
     return CU_get_error();

--- a/test/unit_test/CUnitCharsetSuite.c
+++ b/test/unit_test/CUnitCharsetSuite.c
@@ -13,7 +13,7 @@
  * ValidCode Test
  *-------------------------------------------------------------------------*/
 
-void test_valid_code() 
+void test_valid_code()
 {
     char *input1 = "DD3abC";
     char *input2 = "AB8mb9";
@@ -38,7 +38,7 @@ void test_valid_code()
     CU_ASSERT(validCode(input10));
 }
 
-void test_valid_code_exceptions() 
+void test_valid_code_exceptions()
 {
     char *input1 = "0abcmn";
     char *input2 = "OfrtX6";
@@ -85,7 +85,7 @@ void test_valid_code_short()
     CU_ASSERT_FALSE(validCode(input4));
 }
 
-void test_valid_code_long() 
+void test_valid_code_long()
 {
     char *input1 = "fsdgdfhgfhghkkjhkkghtryt67rhrtu";
     char *input2 = "rtde886";

--- a/test/unit_test/CUnitDropPrivsSuite.c
+++ b/test/unit_test/CUnitDropPrivsSuite.c
@@ -12,7 +12,7 @@
  * Drop_privileges Test
  *-------------------------------------------------------------------------*/
 
-void test_drop_privileges() 
+void test_drop_privileges()
 {
     char *e_user_name_initial = get_effective_user_name();
     char *r_user_name_initial = get_user_name();
@@ -21,7 +21,7 @@ void test_drop_privileges()
     CU_ASSERT_PTR_NOT_NULL_FATAL(r_user_name_initial);
 
     // drop_privs temp
-    int response1 = drop_privileges(0); 
+    int response1 = drop_privileges(0);
     char *e_user_name1 = get_effective_user_name();
     char *r_user_name1 = get_user_name();
 
@@ -31,7 +31,7 @@ void test_drop_privileges()
     CU_ASSERT_STRING_EQUAL(r_user_name1, e_user_name1);
 
     // drop_privs temp again
-    int response2 = drop_privileges(0); 
+    int response2 = drop_privileges(0);
     char *e_user_name2 = get_effective_user_name();
     char *r_user_name2 = get_user_name();
 
@@ -51,7 +51,7 @@ void test_drop_privileges()
     CU_ASSERT_STRING_EQUAL(e_user_name_initial, e_user_name3);
 
     // drop_privs definitely
-    int response4 = drop_privileges(1); 
+    int response4 = drop_privileges(1);
     char *e_user_name4 = get_effective_user_name();
     char *r_user_name4 = get_user_name();
 
@@ -70,7 +70,7 @@ void test_drop_privileges()
     CU_ASSERT_STRING_EQUAL(r_user_name5, e_user_name5);
 
     // drop_privs temp (being dropped definitely)
-    int response6 = drop_privileges(0); 
+    int response6 = drop_privileges(0);
     char *e_user_name6 = get_effective_user_name();
     char *r_user_name6 = get_user_name();
 
@@ -80,7 +80,7 @@ void test_drop_privileges()
     CU_ASSERT_STRING_EQUAL(r_user_name6, e_user_name6);
 
     // drop_privs definitely again
-    int response7 = drop_privileges(1); 
+    int response7 = drop_privileges(1);
     char *e_user_name7 = get_effective_user_name();
     char *r_user_name7 = get_user_name();
 

--- a/test/unit_test/CUnitUtilSuite.c
+++ b/test/unit_test/CUnitUtilSuite.c
@@ -15,7 +15,7 @@ static const char *pConfigFile = "test.conf";
  * GetAccount Test
  *-------------------------------------------------------------------------*/
 
-void test_get_account() 
+void test_get_account()
 {
     const char* input = "user";
     const char* response = getAccountId(input, pAccountsFile);
@@ -25,7 +25,7 @@ void test_get_account()
     CU_ASSERT_STRING_EQUAL(expected, response);
 }
 
-void test_get_account_equals() 
+void test_get_account_equals()
 {
     const char* input1 = "user1";
     const char* input2 = "user2";
@@ -47,7 +47,7 @@ void test_get_account_longer_accountId()
     CU_ASSERT_PTR_NULL(response);
 }
 
-void test_get_account_shorter_accountId() 
+void test_get_account_shorter_accountId()
 {
     const char* input = "user4";
     const char* response = getAccountId(input, pAccountsFile);
@@ -55,7 +55,7 @@ void test_get_account_shorter_accountId()
     CU_ASSERT_PTR_NULL(response);
 }
 
-void test_get_account_no_value() 
+void test_get_account_no_value()
 {
     const char* input = "root";
     const char* response = getAccountId(input, pAccountsFile);
@@ -63,7 +63,7 @@ void test_get_account_no_value()
     CU_ASSERT_PTR_NULL(response);
 }
 
-void test_get_account_user_not_found() 
+void test_get_account_user_not_found()
 {
     const char* input = "bad_user";
     const char* response = getAccountId(input, pAccountsFile);
@@ -76,13 +76,13 @@ void test_get_account_user_not_found()
  * GetConfig Test
  *-------------------------------------------------------------------------*/
 
-void test_get_config() 
+void test_get_config()
 {
     const char* input1 = "app_id";
     const char* input2 = "secret_key";
 
     char *response1;
-    char *response2; 
+    char *response2;
 
     response1 = getConfig(APP_ID_LENGTH, input1, pConfigFile);
     response2 = getConfig(SECRET_KEY_LENGTH, input2, pConfigFile);
@@ -96,13 +96,13 @@ void test_get_config()
     CU_ASSERT_STRING_EQUAL(expected2, response2);
 }
 
-void test_get_config_bad_config_file() 
+void test_get_config_bad_config_file()
 {
     const char* input1 = "app_id";
     const char* input2 = "secret_key";
 
     char *response1;
-    char *response2; 
+    char *response2;
 
     response1 = getConfig(APP_ID_LENGTH, input1, "bad_latch.conf");
     response2 = getConfig(SECRET_KEY_LENGTH, input2, "bad_latch.conf");
@@ -111,13 +111,13 @@ void test_get_config_bad_config_file()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_get_config_longer_length() 
+void test_get_config_longer_length()
 {
     const char* input1 = "app_id_longer";
     const char* input2 = "secret_key_longer";
 
     char *response1;
-    char *response2; 
+    char *response2;
 
     response1 = getConfig(APP_ID_LENGTH, input1, pConfigFile);
     response2 = getConfig(SECRET_KEY_LENGTH, input2, pConfigFile);
@@ -131,13 +131,13 @@ void test_get_config_longer_length()
     CU_ASSERT_STRING_EQUAL(expected2, response2);
 }
 
-void test_get_config_shorter_length() 
+void test_get_config_shorter_length()
 {
     const char* input1 = "app_id_shorter";
     const char* input2 = "secret_key_shorter";
 
     char *response1;
-    char *response2; 
+    char *response2;
 
     response1 = getConfig(APP_ID_LENGTH, input1, pConfigFile);
     response2 = getConfig(SECRET_KEY_LENGTH, input2, pConfigFile);
@@ -151,13 +151,13 @@ void test_get_config_shorter_length()
     CU_ASSERT_STRING_EQUAL(expected2, response2);
 }
 
-void test_get_config_empty() 
+void test_get_config_empty()
 {
     const char* input1 = "app_id";
     const char* input2 = "secret_key";
 
     char *response1;
-    char *response2; 
+    char *response2;
 
     response1 = getConfig(APP_ID_LENGTH, input1, "empty.conf");
     response2 = getConfig(SECRET_KEY_LENGTH, input2, "empty.conf");
@@ -166,13 +166,13 @@ void test_get_config_empty()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_get_config_no_value() 
+void test_get_config_no_value()
 {
     const char* input1 = "app_id_no_value";
     const char* input2 = "secret_key_no_value";
 
     char *response1 = NULL;
-    char *response2 = NULL; 
+    char *response2 = NULL;
 
     response1 = getConfig(APP_ID_LENGTH, input1, pConfigFile);
     response2 = getConfig(SECRET_KEY_LENGTH, input2, pConfigFile);
@@ -181,11 +181,11 @@ void test_get_config_no_value()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_get_config_gt_bufsiz() 
+void test_get_config_gt_bufsiz()
 {
     FILE *fd = fopen("temp.conf", "w");
     fprintf(fd, "app_id_gt_bufsiz = ");
-        
+
     int i;
     for (i = 0 ; i < BUFSIZ + 10 ; i++) {
         fprintf(fd, "X");
@@ -204,7 +204,7 @@ void test_get_config_gt_bufsiz()
     const char* input2 = "secret_key_gt_bufsiz";
 
     char *response1;
-    char *response2; 
+    char *response2;
 
     response1 = getConfig(APP_ID_LENGTH, input1, "temp.conf");
     response2 = getConfig(SECRET_KEY_LENGTH, input2, "temp.conf");
@@ -225,7 +225,7 @@ void test_get_config_gt_bufsiz()
  * CountAccountId Test
  *-------------------------------------------------------------------------*/
 
-void test_count_account() 
+void test_count_account()
 {
     const char* input1 = "ddd917b408a782408a3961978a82a664461eb7dd2f9b97236202e290489d98b8";
     const char* input2 = "123xxxbrt8a782408a396197bv82a664b61eb7dd2f9b97236202e290489d9777";
@@ -248,7 +248,7 @@ void test_count_account()
     CU_ASSERT_TRUE(response4 == expected4);
 }
 
-void test_count_account_bad_length() 
+void test_count_account_bad_length()
 {
     const char* input = "yuihdcvbn8a782408a397236202e2904rffmjh3";
     int response = countAccountId(input, pAccountsFile);
@@ -257,7 +257,7 @@ void test_count_account_bad_length()
     CU_ASSERT_TRUE(response == expected);
 }
 
-void test_count_account_null() 
+void test_count_account_null()
 {
     int response = countAccountId(NULL, pAccountsFile);
     int expected = -1;
@@ -265,7 +265,7 @@ void test_count_account_null()
     CU_ASSERT_TRUE(response == expected);
 }
 
-void test_count_account_null_acc_file() 
+void test_count_account_null_acc_file()
 {
     const char* input = "ddd917b408a782408a3961978a82a664461eb7dd2f9b97236202e290489d98b8";
     int response = countAccountId(input, NULL);
@@ -274,7 +274,7 @@ void test_count_account_null_acc_file()
     CU_ASSERT_TRUE(response == expected);
 }
 
-void test_count_account_bad_acc_file() 
+void test_count_account_bad_acc_file()
 {
     const char* input = "ddd917b408a782408a3961978a82a664461eb7dd2f9b97236202e290489d98b8";
     int response = countAccountId(input, "bad_acc_file.accounts");
@@ -289,7 +289,7 @@ void test_count_account_bad_acc_file()
  * AppendAccountId Test
  *-------------------------------------------------------------------------*/
 
-void test_append_accountId() 
+void test_append_accountId()
 {
     const char* input = "ddd917b408a782408a3961978a82a664461eb7dd2f9b97236202e290489d98b8";
     int response1 = appendAccountId("username", input, pAccountsFile);
@@ -302,7 +302,7 @@ void test_append_accountId()
     CU_ASSERT_STRING_EQUAL(expected2, response2);
 }
 
-void test_append_accountId_longer() 
+void test_append_accountId_longer()
 {
     const char* input = "ddd917b408a782408a3961978a82a664461eb7dd2f9b97236202e290489d98b8t543tst45";
     int response1 = appendAccountId("username_longer", input, pAccountsFile);
@@ -313,7 +313,7 @@ void test_append_accountId_longer()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_append_accountId_shorter() 
+void test_append_accountId_shorter()
 {
     const char* input = "4461eb7dd2f9b97236202e290489d98b8t543tst45";
     int response1 = appendAccountId("username_shorter", input, pAccountsFile);
@@ -324,7 +324,7 @@ void test_append_accountId_shorter()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_append_accountId_no_value() 
+void test_append_accountId_no_value()
 {
     const char* input = "";
     int response1 = appendAccountId("username_no_value", input, pAccountsFile);
@@ -335,7 +335,7 @@ void test_append_accountId_no_value()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_append_accountId_no_file() 
+void test_append_accountId_no_file()
 {
     const char* input = "ddd917b408a782408a3961978a82a664461eb7dd2f9b97236202e290489d98b8";
     int response1 = appendAccountId("username_no_file", input, "no_file");
@@ -356,7 +356,7 @@ void test_append_accountId_no_file()
  * DeleteAccountId Test
  *-------------------------------------------------------------------------*/
 
-void test_delete_accountId() 
+void test_delete_accountId()
 {
     int response1 = deleteAccountId("username", pAccountsFile);
 
@@ -366,7 +366,7 @@ void test_delete_accountId()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_delete_accountId_longer() 
+void test_delete_accountId_longer()
 {
     int response1 = deleteAccountId("username_longer", pAccountsFile);
 
@@ -376,7 +376,7 @@ void test_delete_accountId_longer()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_delete_accountId_shorter() 
+void test_delete_accountId_shorter()
 {
     int response1 = deleteAccountId("username_shorter", pAccountsFile);
 
@@ -386,7 +386,7 @@ void test_delete_accountId_shorter()
     CU_ASSERT_PTR_NULL(response2);
 }
 
-void test_delete_accountId_no_value() 
+void test_delete_accountId_no_value()
 {
     int response1 = deleteAccountId("username_no_value", pAccountsFile);
 
@@ -397,7 +397,7 @@ void test_delete_accountId_no_value()
 
 }
 
-void test_delete_accountId_no_file() 
+void test_delete_accountId_no_file()
 {
     int response = deleteAccountId("username_no_file", "no_file");
 


### PR DESCRIPTION
latch_ssh_command.c and latch_unix.c were lacking the include string.h, so compiler was complaining about implicit function uses. 

Trailing whitespaces were also cleaned