### PR TITLE
"latch-shell-cmd" instead of "latch-shell"

### DIFF
--- a/examples/debian/home/user/ssh/authorized_keys
+++ b/examples/debian/home/user/ssh/authorized_keys
@@ -1,5 +1,5 @@
-command="latch-shell -o sshd-keys" ssh-rsa AAA...HP5 someone@host
+command="latch-shell-cmd -o sshd-keys" ssh-rsa AAA...HP5 someone@host
 
-command="latch-shell -o sshd-keys" ssh-rsa ABB...A7R someone@host
+command="latch-shell-cmd -o sshd-keys" ssh-rsa ABB...A7R someone@host
 
-command="latch-shell -o sshd-keys" ssh-rsa ABC...3AA someone@host
+command="latch-shell-cmd -o sshd-keys" ssh-rsa ABC...3AA someone@host


### PR DESCRIPTION
I think this is an error using the command "latch-shell-cmd". See the UNIX latch plugin manual (https://latch.elevenpaths.com/www/public/documents/resources/plugin_manuals/en/UNIX.pdf) page 10, section 2.2.1.:

> The end result should be:
> command="latch-ssh-cmd -o sshd-keys" ssh-rsa AAA...HP5 someone@host
